### PR TITLE
README docs: Add autoconf to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ btcdeb depends on the following:
 
 * libtool
 * libssl
+* autoconf
 
-Ubuntu/debian users can do: `apt-get install libtool libssl-dev` (with `sudo` prepended if necessary)
+Ubuntu/debian users can do: `apt-get install libtool libssl-dev autoconf` (with `sudo` prepended if necessary)
 
 Mac users can do: `brew install libtool`
 


### PR DESCRIPTION
Context: Installed btcdeb this morning on a fresh Debian machine (PureOS distribution).

Nit: In addition to libssl-dev and libtool, autoconf was a required dependency. It might not be present by default in a new environment. Thus, this minor proposed doc change.

Cheers.

[skip ci]