### PR TITLE
add --pretend-valid option and op(arg) feature

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -196,7 +196,8 @@ btcc_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 
 btcc_LDADD = \
 	$(LIBBITCOIN_DEB) \
-	$(LIBBITCOIN)
+	$(LIBBITCOIN) \
+	$(LIBSECP256K1)
 
 # test-btcdeb binary #
 test_btcdeb_SOURCES = \

--- a/btcdeb.cpp
+++ b/btcdeb.cpp
@@ -97,15 +97,16 @@ int main(int argc, char* const* argv)
     ca.add_option("txin", 'i', req_arg);
     ca.add_option("modify-flags", 'f', req_arg);
     ca.add_option("select", 's', req_arg);
+    ca.add_option("pretend-valid", 'P', req_arg);
     ca.add_option("default-flags", 'd', no_arg);
     ca.parse(argc, argv);
     quiet = ca.m.count('q') || pipe_in || pipe_out;
 
     if (ca.m.count('h')) {
-        fprintf(stderr, "Syntax: %s [-q|--quiet] [--tx=[amount1,amount2,..:]<hex> [--txin=<hex>] [--modify-flags=<flags>|-f<flags>] [--select=<index>|-s<index>] [<script> [<stack bottom item> [... [<stack top item>]]]]]\n", argv[0]);
+        fprintf(stderr, "Syntax: %s [-q|--quiet] [--tx=[amount1,amount2,..:]<hex> [--txin=<hex>] [--modify-flags=<flags>|-f<flags>] [--select=<index>|-s<index>] [--pretend-valid=<sig>:<pubkey>[,<sig2>:<pubkey2>[,...]]|-P<sig>:<pubkey>[,...]] [<script> [<stack bottom item> [... [<stack top item>]]]]]\n", argv[0]);
         fprintf(stderr, "If executed with no arguments, an empty script and empty stack is provided\n");
-        fprintf(stderr, "To debug transaction signatures, you need to provide the transaction hex (the WHOLE hex, not just the txid) "
-            "as well as (SegWit only) every amount for the inputs\n");
+        fprintf(stderr, "To debug transaction signatures, you need to either provide the transaction hex (the WHOLE hex, not just the txid) "
+            "as well as (SegWit only) every amount for the inputs, or provide (one or more) signature:pubkey pairs using --pretend-valid\n");
         fprintf(stderr, "E.g. if a SegWit transaction abc123... has 2 inputs of 0.1 btc and 0.002 btc, you would do tx=0.1,0.002:abc123...\n");
         fprintf(stderr, "You do not need the amounts for non-SegWit transactions\n");
         fprintf(stderr, "By providing a txin as well as a tx and no script or stack, btcdeb will attempt to set up a debug session for the verification of the given input by pulling the appropriate values out of the respective transactions. you do not need amounts for --tx in this case\n");
@@ -181,6 +182,12 @@ int main(int argc, char* const* argv)
     }
 
     instance.parse_stack_args(ca.l);
+
+    if (ca.m.count('P')) {
+        if (!instance.parse_pretend_valid_expr(ca.m['P'].c_str())) {
+            return 1;
+        }
+    }
 
     if (instance.txin && instance.tx && ca.l.size() == 0 && instance.script.size() == 0) {
         if (!instance.configure_tx_txin()) return 1;

--- a/instance.h
+++ b/instance.h
@@ -8,6 +8,7 @@
 #include <pubkey.h>
 #include <value.h>
 #include <vector>
+#include <map>
 
 typedef std::vector<unsigned char> valtype;
 
@@ -28,6 +29,15 @@ public:
     BaseSignatureChecker* checker;
     ScriptError error;
     std::string exception_string = "";
+    /**
+     * Mapping of pubkeys to signatures that should be considered cryptographically valid.
+     *
+     * For the keypair <key>=<value>, if a signature <value> is checked against a pubkey <key>
+     * for any signature hash <hash>, the cryptographic check is skipped and the signature is
+     * assumed to be valid.
+     */
+    std::map<valtype,valtype> pretend_valid_map;
+    std::set<valtype> pretend_valid_pubkeys;
 
     Instance()
     : env(nullptr)
@@ -51,6 +61,8 @@ public:
 
     void parse_stack_args(size_t argc, char* const* argv, size_t starting_index);
     void parse_stack_args(const std::vector<const char*> args);
+
+    bool parse_pretend_valid_expr(const char* expr);
 
     bool configure_tx_txin();
 

--- a/script/interpreter.h
+++ b/script/interpreter.h
@@ -200,6 +200,8 @@ struct ScriptExecutionEnvironment {
     const BaseSignatureChecker& checker;
     SigVersion sigversion;
     ScriptError* serror;
+    std::map<std::vector<unsigned char>,std::vector<unsigned char>> pretend_valid_map;
+    std::set<std::vector<unsigned char>> pretend_valid_pubkeys;
     ScriptExecutionEnvironment(std::vector<std::vector<unsigned char> >& stack_in, const CScript& script_in, unsigned int flags_in, const BaseSignatureChecker& checker_in);
 };
 

--- a/utilstrencodings.h
+++ b/utilstrencodings.h
@@ -12,6 +12,7 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include <functional>
 
 #define BEGIN(a)            ((char*)&(a))
 #define END(a)              ((char*)&((&(a))[1]))
@@ -148,6 +149,18 @@ bool TimingResistantEqual(const T& a, const T& b)
  * @note The result must be in the range (-10^18,10^18), otherwise an overflow error will trigger.
  */
 bool ParseFixedPoint(const std::string &val, int decimals, int64_t *amount_out);
+
+template <typename Tset, typename Tel>
+inline std::string Join(const Tset& iterable, const std::string& sep,
+        std::function<std::string(const Tel&)> strfun) {
+    std::string rv = "";
+    for (const Tel& el : iterable) {
+        rv += (rv[0] ? ", " : "") + strfun(el);
+    }
+    return rv;
+}
+
+inline std::string JoinHexStrFun(const std::vector<unsigned char>& t) { return HexStr(t); }
 
 /** Convert from one power-of-2 number base to another. */
 template<int frombits, int tobits, bool pad, typename O, typename I>

--- a/value.h
+++ b/value.h
@@ -278,9 +278,8 @@ struct Value {
             return HexStr(CScriptNum::serialize(int64));
         case T_DATA:
             return HexStr(data);
-        default:
-            fprintf(stderr, "cannot convert string into hex value: %s\n", str.c_str());
-            return "";
+        case T_STRING:
+            return HexStr(data_value());
         }
     }
     int64_t int_value() const {


### PR DESCRIPTION
Closes #32.

A new option to pretend that a pubkey+signature pair is valid without actually checking the signature itself, and a new feature which lets you do op(arg) to do on-the-fly conversions. This is used in example below.

The former is useful when playing around with scripts where you don't want to bother creating pubkeys and signatures and such.

If we start with a real world case:

> btcdeb '[OP_2 OP_DROP 30440220192b64bb3952c144ead43fdb5286007388785d81fd90ecedfba8bf7a5ea0a1ad02205891ceb16a793adad74497ee5f4a3eb42f6a6e4e1602b540f434e711a7d3521b01 02ab74ff5864c29ab400030afc05a7c141c4970707fef9dbb0ac24115867c987a5 OP_DUP OP_HASH160 ccbdfc0f1e5fc51e01d50c9ebc37ca7c323c05b5 OP_EQUALVERIFY OP_CHECKSIG]' --pretend-valid=30440220192b64bb3952c144ead43fdb5286007388785d81fd90ecedfba8bf7a5ea0a1ad02205891ceb16a793adad74497ee5f4a3eb42f6a6e4e1602b540f434e711a7d3521b01:02ab74ff5864c29ab400030afc05a7c141c4970707fef9dbb0ac24115867c987a5

We can shrink this down to something like this:

> btcdeb '[OP_2 OP_DROP sig1 pub1 OP_DUP OP_HASH160 0c3071cf08289580e0e2030a388998460efd39e1 OP_EQUALVERIFY OP_CHECKSIG]' --pretend-valid=sig1:pub1

This will skip the signature check. Annoyingly you need to calculate the HASH160 of the string "pub1" for the OP_EQUALVERIFY part of the script, but the new op(arg) feature lets you write this as "hash160(pub1)", i.e.:

> btcdeb '[OP_2 OP_DROP sig1 pub1 OP_DUP OP_HASH160 hash160(pub1) OP_EQUALVERIFY OP_CHECKSIG]' --pretend-valid=sig1:pub1

Ping @kanzure -- merging this; let me know if this is not what you meant.