### PR TITLE
Restore templating opcodes

### DIFF
--- a/btcdeb.cpp
+++ b/btcdeb.cpp
@@ -432,11 +432,12 @@ static const char* opnames[] = {
     "OP_NOP9",
     "OP_NOP10",
 
-    // // template matching params
-    // "OP_SMALLINTEGER",
-    // "OP_PUBKEYS",
-    // "OP_PUBKEYHASH",
-    // "OP_PUBKEY",
+    // template matching params
+    "OP_SMALLINTEGER",
+    "OP_PUBKEYS",
+    "OP_PUBKEYHASH",
+    "OP_PUBKEY",
+
     nullptr,
 };
 

--- a/debugger/script.cpp
+++ b/debugger/script.cpp
@@ -22,8 +22,10 @@ btc_logf_t btc_segwit_logf = btc_logf_dummy;
 opcodetype GetOpCode(const char* name)
 {
     // trim out "OP_" as people tend to skip those
+    bool expected_opcode = false;
     if (name[0] == 'O' && name[1] == 'P' && name[2] == '_') {
         name = &name[3];
+        expected_opcode = true;
     }
     // push value
     #define c(v) if (!strcmp(#v, name)) return OP_##v
@@ -161,6 +163,9 @@ opcodetype GetOpCode(const char* name)
     c(PUBKEYHASH);
     c(PUBKEY);
 
+    if (expected_opcode) {
+        btc_logf("warning: opcode-like string was not an opcode: %s\n", name);
+    }
     return OP_INVALIDOPCODE;
 }
 

--- a/debugger/script.cpp
+++ b/debugger/script.cpp
@@ -155,6 +155,12 @@ opcodetype GetOpCode(const char* name)
     c(NOP9);
     c(NOP10);
 
+    // template matching params
+    c(SMALLINTEGER);
+    c(PUBKEYS);
+    c(PUBKEYHASH);
+    c(PUBKEY);
+
     return OP_INVALIDOPCODE;
 }
 
@@ -266,6 +272,12 @@ void GetStackFeatures(opcodetype opcode, size_t& spawns, size_t& slays)
     case OP_NOP8                   :
     case OP_NOP9                   :
     case OP_NOP10                  : _(0, 0);
+
+    // template matching params
+    case OP_SMALLINTEGER           :
+    case OP_PUBKEYS                :
+    case OP_PUBKEYHASH             :
+    case OP_PUBKEY                 : _(1, 0);
 
     default:
         _(1, 0); // default is all the push commands

--- a/script/script.cpp
+++ b/script/script.cpp
@@ -138,6 +138,12 @@ const char* GetOpName(opcodetype opcode)
     case OP_NOP9                   : return "OP_NOP9";
     case OP_NOP10                  : return "OP_NOP10";
 
+    // template matching params
+    case OP_SMALLINTEGER           : return "OP_SMALLINTEGER";
+    case OP_PUBKEYS                : return "OP_PUBKEYS";
+    case OP_PUBKEYHASH             : return "OP_PUBKEYHASH";
+    case OP_PUBKEY                 : return "OP_PUBKEY";
+
     case OP_INVALIDOPCODE          : return "OP_INVALIDOPCODE";
 
     default:

--- a/script/script.h
+++ b/script/script.h
@@ -187,6 +187,12 @@ enum opcodetype
     OP_NOP9 = 0xb8,
     OP_NOP10 = 0xb9,
 
+    // template matching params
+    OP_SMALLINTEGER = 0xfa,
+    OP_PUBKEYS = 0xfb,
+    OP_PUBKEYHASH = 0xfd,
+    OP_PUBKEY = 0xfe,
+
     OP_INVALIDOPCODE = 0xff,
 };
 


### PR DESCRIPTION
Some templating opcodes were inadvertently removed and have been restored.

Fixes #46.