### PR TITLE
emit warning when interpreting opcode-like non-opcodes

### DIFF
--- a/debugger/script.cpp
+++ b/debugger/script.cpp
@@ -22,8 +22,10 @@ btc_logf_t btc_segwit_logf = btc_logf_dummy;
 opcodetype GetOpCode(const char* name)
 {
     // trim out "OP_" as people tend to skip those
+    bool expected_opcode = false;
     if (name[0] == 'O' && name[1] == 'P' && name[2] == '_') {
         name = &name[3];
+        expected_opcode = true;
     }
     // push value
     #define c(v) if (!strcmp(#v, name)) return OP_##v
@@ -155,6 +157,9 @@ opcodetype GetOpCode(const char* name)
     c(NOP9);
     c(NOP10);
 
+    if (expected_opcode) {
+        btc_logf("warning: opcode-like string was not an opcode: %s\n", name);
+    }
     return OP_INVALIDOPCODE;
 }
 


### PR DESCRIPTION
Anything starting with OP_ (case sensitive) that is not a known opcode will emit a warning to btc_logf (which can be silenced with the quiet flag).